### PR TITLE
Add hCaptcha support to registration captcha

### DIFF
--- a/docs/documentation/server_admin/topics/users/proc-enabling-recaptcha.adoc
+++ b/docs/documentation/server_admin/topics/users/proc-enabling-recaptcha.adoc
@@ -6,7 +6,7 @@
 = Enabling reCAPTCHA
 
 [role="_abstract"]
-To safeguard registration against bots, {project_name} has integration with Google reCAPTCHA (see <<procedure_recaptcha>>) and reCAPTCHA Enterprise (see <<procedure_recaptcha_enterprise>>).
+To safeguard registration against bots, {project_name} has integration with Google reCAPTCHA (see <<procedure_recaptcha>>), hCaptcha (see <<procedure_hcaptcha>>), and reCAPTCHA Enterprise (see <<procedure_recaptcha_enterprise>>).
 The default theme (`register.ftl`) supports both v2 (visible, checkbox-based) and v3 (score-based, invisible) reCAPTCHA (see https://cloud.google.com/recaptcha/docs/choose-key-type[Choose the appropriate reCAPTCHA key type]).
 
 [[procedure_recaptcha]]
@@ -48,6 +48,29 @@ NOTE: In {project_name}, websites cannot include a login page dialog in an ifram
 .. Enter `https://www.google.com` in the field for the *X-Frame-Options* header (or `https//www.recaptcha.net` if you enabled *Use recaptcha.net*).
 .. Enter `https://www.google.com` in the field for the *Content-Security-Policy* header (or `https//www.recaptcha.net` if you enabled *Use recaptcha.net*).
 
+
+[[procedure_hcaptcha]]
+== Setting up hCaptcha
+
+. Enter the following URL in a browser:
++
+[source,bash,subs=+attributes]
+----
+https://www.hcaptcha.com/
+----
+
+. Sign in and create a site in the hCaptcha dashboard to obtain your *Site Key* and *Secret*. Note them down for future use in this procedure.
+. Navigate to the {project_name} admin console.
+. Click *Authentication* in the menu.
+. Click the *Flows* tab.
+. Select *Registration* from the list.
+. Add the *hCaptcha* execution as a sub-step of *Registration Form* and set its requirement to *Required*.
+. Click the *gear icon* ⚙️ on the *hCaptcha* row.
+
++
+. Enter the *hCaptcha Site Key* generated from the hCaptcha dashboard.
+. Enter the *hCaptcha Secret* generated from the hCaptcha dashboard.
+. Save the configuration.
 
 [[procedure_recaptcha_enterprise]]
 == Setting up Google reCAPTCHA Enterprise

--- a/services/src/main/java/org/keycloak/authentication/forms/AbstractRegistrationRecaptcha.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/AbstractRegistrationRecaptcha.java
@@ -22,6 +22,7 @@ package org.keycloak.authentication.forms;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import org.jboss.logging.Logger;
@@ -47,6 +48,8 @@ import org.keycloak.utils.StringUtil;
 public abstract class AbstractRegistrationRecaptcha implements FormAction, FormActionFactory {
 
     public static final String G_RECAPTCHA_RESPONSE = "g-recaptcha-response";
+    public static final String H_CAPTCHA_RESPONSE = "h-captcha-response";
+    public static final Set<String> CAPTCHA_RESPONSE_FIELDS = Set.of(G_RECAPTCHA_RESPONSE, H_CAPTCHA_RESPONSE);
     public static final String RECAPTCHA_REFERENCE_CATEGORY = "recaptcha";
 
     // option keys
@@ -97,24 +100,43 @@ public abstract class AbstractRegistrationRecaptcha implements FormAction, FormA
 
         String userLanguageTag = context.getSession().getContext().resolveLocale(context.getUser())
                 .toLanguageTag();
-        boolean invisible = Boolean.parseBoolean(config.get(INVISIBLE));
-        String action = StringUtil.isNullOrEmpty(config.get(ACTION)) ? "register" : config.get(ACTION);
+        boolean invisible = isInvisible(config);
+        String action = resolveAction(config);
 
         form.setAttribute("recaptchaRequired", true);
         form.setAttribute("recaptchaSiteKey", config.get(SITE_KEY));
         form.setAttribute("recaptchaAction", action);
         form.setAttribute("recaptchaVisible", !invisible);
+        form.setAttribute("recaptchaProviderId", getId());
+
+        form.setAttribute("captchaRequired", true);
+        form.setAttribute("captchaSiteKey", config.get(SITE_KEY));
+        form.setAttribute("captchaAction", action);
+        form.setAttribute("captchaVisible", !invisible);
+        form.setAttribute("captchaProviderId", getId());
+
         form.addScript(getScriptUrl(config, userLanguageTag));
+    }
+
+    protected boolean isInvisible(Map<String, String> config) {
+        return Boolean.parseBoolean(config.get(INVISIBLE));
+    }
+
+    protected String resolveAction(Map<String, String> config) {
+        String action = config.get(ACTION);
+        return StringUtil.isNullOrEmpty(action) ? "register" : action;
     }
 
     protected abstract String getScriptUrl(Map<String, String> config, String userLanguageTag);
 
     protected abstract boolean validateConfig(Map<String, String> config);
 
+    protected abstract String getResponseFieldName();
+
     @Override
     public void validate(ValidationContext context) {
         MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
-        String captcha = formData.getFirst(G_RECAPTCHA_RESPONSE);
+        String captcha = formData.getFirst(getResponseFieldName());
         LOGGER.trace("Got captcha: " + captcha);
 
         Map<String, String> config = context.getAuthenticatorConfig().getConfig();

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationHCaptcha.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationHCaptcha.java
@@ -1,20 +1,3 @@
-/*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.keycloak.authentication.forms;
 
 import java.io.InputStream;
@@ -33,68 +16,48 @@ import org.apache.http.util.EntityUtils;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.ValidationContext;
 import org.keycloak.connections.httpclient.HttpClientProvider;
-import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.StringUtil;
 
-public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
+public class RegistrationHCaptcha extends AbstractRegistrationRecaptcha {
 
-    private static final Logger LOGGER = Logger.getLogger(RegistrationRecaptcha.class);
-    public static final String PROVIDER_ID = "registration-recaptcha-action";
+    private static final Logger LOGGER = Logger.getLogger(RegistrationHCaptcha.class);
 
-    // option keys
+    public static final String PROVIDER_ID = "registration-hcaptcha-action";
     public static final String SECRET_KEY = "secret.key";
-    public static final String OLD_SECRET = "secret";
 
     @Override
     public String getDisplayType() {
-        return "reCAPTCHA";
+        return "hCaptcha";
     }
 
     @Override
     public String getHelpText() {
-        return "Adds Google reCAPTCHA to the form.";
+        return "Adds hCaptcha to the form.";
     }
 
     @Override
-    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
-        return new AuthenticationExecutionModel.Requirement[] {
-                AuthenticationExecutionModel.Requirement.REQUIRED,
-                AuthenticationExecutionModel.Requirement.DISABLED
-        };
+    public String getId() {
+        return PROVIDER_ID;
     }
 
     @Override
     protected boolean validateConfig(Map<String, String> config) {
-        return !StringUtil.isNullOrEmpty(config.get(SITE_KEY)) &&
-                (!StringUtil.isNullOrEmpty(config.get(SECRET_KEY)) || !StringUtil.isNullOrEmpty(config.get(OLD_SECRET)));
-    }
-
-    @Override
-    protected String getResponseFieldName() {
-        return G_RECAPTCHA_RESPONSE;
+        return !StringUtil.isNullOrEmpty(config.get(SITE_KEY))
+                && !StringUtil.isNullOrEmpty(config.get(SECRET_KEY));
     }
 
     @Override
     protected boolean validate(ValidationContext context, String captcha, Map<String, String> config) {
-        LOGGER.trace("Verifying reCAPTCHA using non-enterprise API");
+        LOGGER.trace("Verifying hCaptcha token");
         CloseableHttpClient httpClient = context.getSession().getProvider(HttpClientProvider.class).getHttpClient();
 
-        HttpPost post = new HttpPost("https://www." + getRecaptchaDomain(config) + "/recaptcha/api/siteverify");
+        HttpPost post = new HttpPost("https://hcaptcha.com/siteverify");
         List<NameValuePair> formparams = new LinkedList<>();
-        String secret = config.get(SECRET_KEY);
-        if (StringUtil.isNullOrEmpty(secret)) {
-            // migrate old config name to the new one
-            secret = config.get(OLD_SECRET);
-            if (!StringUtil.isNullOrEmpty(secret)) {
-                config.put(SECRET_KEY, secret);
-                config.remove(OLD_SECRET);
-            }
-        }
-        formparams.add(new BasicNameValuePair("secret", secret));
+        formparams.add(new BasicNameValuePair("secret", config.get(SECRET_KEY)));
         formparams.add(new BasicNameValuePair("response", captcha));
         if (context.getConnection().getRemoteAddr() != null) {
             formparams.add(new BasicNameValuePair("remoteip", context.getConnection().getRemoteAddr()));
@@ -120,32 +83,40 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
     @Override
     protected String getScriptUrl(Map<String, String> config, String userLanguageTag) {
-        return "https://www." + getRecaptchaDomain(config) + "/recaptcha/api.js?hl=" + userLanguageTag;
+        return "https://hcaptcha.com/1/api.js?hl=" + userLanguageTag;
     }
 
     @Override
-    public String getId() {
-        return PROVIDER_ID;
+    protected String resolveAction(Map<String, String> config) {
+        return null;
+    }
+
+    @Override
+    protected boolean isInvisible(Map<String, String> config) {
+        return false;
+    }
+
+    @Override
+    protected String getResponseFieldName() {
+        return H_CAPTCHA_RESPONSE;
     }
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        List<ProviderConfigProperty> properties = ProviderConfigurationBuilder.create()
+        return ProviderConfigurationBuilder.create()
                 .property()
                 .name(SITE_KEY)
-                .label("reCAPTCHA Site Key")
+                .label("hCaptcha Site Key")
                 .helpText("The site key.")
                 .type(ProviderConfigProperty.STRING_TYPE)
                 .add()
                 .property()
                 .name(SECRET_KEY)
-                .label("reCAPTCHA Secret")
+                .label("hCaptcha Secret")
                 .helpText("The secret key.")
                 .type(ProviderConfigProperty.STRING_TYPE)
                 .secret(true)
                 .add()
                 .build();
-        properties.addAll(super.getConfigProperties());
-        return properties;
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationPage.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationPage.java
@@ -52,7 +52,7 @@ public class RegistrationPage implements FormAuthenticator, FormAuthenticatorFac
     public static final String FIELD_USERNAME = "username";
     public static final String FIELD_LAST_NAME = "lastName";
     public static final String FIELD_FIRST_NAME = "firstName";
-    public static final String FIELD_RECAPTCHA_RESPONSE = "g-recaptcha-response";
+    public static final String FIELD_RECAPTCHA_RESPONSE = AbstractRegistrationRecaptcha.G_RECAPTCHA_RESPONSE;
     public static final String PROVIDER_ID = "registration-page-form";
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptchaEnterprise.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptchaEnterprise.java
@@ -72,6 +72,11 @@ public class RegistrationRecaptchaEnterprise extends AbstractRegistrationRecaptc
     }
 
     @Override
+    protected String getResponseFieldName() {
+        return G_RECAPTCHA_RESPONSE;
+    }
+
+    @Override
     protected String getScriptUrl(Map<String, String> config, String userLanguageTag) {
         return "https://www." + getRecaptchaDomain(config) + "/recaptcha/enterprise.js?hl=" + userLanguageTag;
 

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
@@ -262,8 +262,8 @@ public class RegistrationUserCreation implements FormAction, FormActionFactory {
     private MultivaluedMap<String, String> normalizeFormParameters(MultivaluedMap<String, String> formParams) {
         MultivaluedHashMap<String, String> copy = new MultivaluedHashMap<>(formParams);
 
-        // Remove google recaptcha form property to avoid length errors
-        copy.remove(RegistrationPage.FIELD_RECAPTCHA_RESPONSE);
+        // Remove captcha form properties to avoid length errors
+        AbstractRegistrationRecaptcha.CAPTCHA_RESPONSE_FIELDS.forEach(copy::remove);
         // Remove "password" and "password-confirm" to avoid leaking them in the user-profile data
         copy.remove(RegistrationPage.FIELD_PASSWORD);
         copy.remove(RegistrationPage.FIELD_PASSWORD_CONFIRM);

--- a/services/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
@@ -18,5 +18,6 @@
 org.keycloak.authentication.forms.RegistrationPassword
 org.keycloak.authentication.forms.RegistrationUserCreation
 org.keycloak.authentication.forms.RegistrationRecaptcha
+org.keycloak.authentication.forms.RegistrationHCaptcha
 org.keycloak.authentication.forms.RegistrationRecaptchaEnterprise
 org.keycloak.authentication.forms.RegistrationTermsAndConditions

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/ProvidersTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/ProvidersTest.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.keycloak.authentication.authenticators.broker.IdpCreateUserIfUniqueAuthenticatorFactory;
+import org.keycloak.authentication.forms.RegistrationHCaptcha;
 import org.keycloak.authentication.forms.RegistrationRecaptcha;
 import org.keycloak.authentication.forms.RegistrationRecaptchaEnterprise;
 import org.keycloak.representations.idm.AuthenticatorConfigInfoRepresentation;
@@ -65,6 +66,7 @@ public class ProvidersTest extends AbstractAuthenticationTest {
 
         List<Map<String, Object>> expected = new LinkedList<>();
         addProviderInfo(expected, RegistrationRecaptcha.PROVIDER_ID, "reCAPTCHA", "Adds Google reCAPTCHA to the form.");
+        addProviderInfo(expected, RegistrationHCaptcha.PROVIDER_ID, "hCaptcha", "Adds hCaptcha to the form.");
         addProviderInfo(expected, RegistrationRecaptchaEnterprise.PROVIDER_ID, "reCAPTCHA Enterprise", "Adds Google reCAPTCHA Enterprise to the form.");
         addProviderInfo(expected, "registration-password-action", "Password Validation",
                 "Validates that password matches password confirmation field.  It also will store password in user's credential store.");

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/address/login/register.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/address/login/register.ftl
@@ -107,10 +107,15 @@
                     <input type="text" class="${properties.kcInputClass!}"  id="user.attributes.country" name="user.attributes.country" value="${(register.formData['user.attributes.country']!'')}"/>
                 </div>
             </div>
+            <#assign captchaProviderId = captchaProviderId!recaptchaProviderId!"" />
             <#if recaptchaRequired??>
             <div class="form-group">
                 <div class="${properties.kcInputWrapperClass!}">
-                    <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                    <#if captchaProviderId == "registration-hcaptcha-action">
+                        <div class="h-captcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                    <#else>
+                        <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                    </#if>
                 </div>
             </div>
             </#if>

--- a/themes/src/main/resources/theme/base/login/register.ftl
+++ b/themes/src/main/resources/theme/base/login/register.ftl
@@ -73,10 +73,15 @@
 
             <@registerCommons.termsAcceptance/>
 
+            <#assign captchaProviderId = captchaProviderId!recaptchaProviderId!"" />
             <#if recaptchaRequired?? && (recaptchaVisible!false)>
                 <div class="form-group">
                     <div class="${properties.kcInputWrapperClass!}">
-                        <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}" data-action="${recaptchaAction}"></div>
+                        <#if captchaProviderId == "registration-hcaptcha-action">
+                            <div class="h-captcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                        <#else>
+                            <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"<#if recaptchaAction?has_content> data-action="${recaptchaAction}"</#if>></div>
+                        </#if>
                     </div>
                 </div>
             </#if>
@@ -95,10 +100,14 @@
                         }
                     </script>
                     <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
-                        <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} g-recaptcha" 
-                            data-sitekey="${recaptchaSiteKey}" data-callback='onSubmitRecaptcha' data-action='${recaptchaAction}' type="submit">
-                            ${msg("doRegister")}
-                        </button>
+                        <#if captchaProviderId == "registration-hcaptcha-action">
+                            <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}"/>
+                        <#else>
+                            <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} g-recaptcha"
+                                data-sitekey="${recaptchaSiteKey}" data-callback='onSubmitRecaptcha'<#if recaptchaAction?has_content> data-action='${recaptchaAction}'</#if> type="submit">
+                                ${msg("doRegister")}
+                            </button>
+                        </#if>
                     </div>
                 <#else>
                     <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">

--- a/themes/src/main/resources/theme/keycloak.v2/login/register.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/register.ftl
@@ -26,10 +26,15 @@
 
             <@registerCommons.termsAcceptance/>
 
+            <#assign captchaProviderId = captchaProviderId!recaptchaProviderId!"" />
             <#if recaptchaRequired?? && (recaptchaVisible!false)>
                 <div class="form-group">
                     <div class="${properties.kcInputWrapperClass!}">
-                        <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}" data-action="${recaptchaAction}"></div>
+                        <#if captchaProviderId == "registration-hcaptcha-action">
+                            <div class="h-captcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                        <#else>
+                            <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"<#if recaptchaAction?has_content> data-action="${recaptchaAction}"</#if>></div>
+                        </#if>
                     </div>
                 </div>
             </#if>
@@ -41,10 +46,14 @@
                     }
                 </script>
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
-                    <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} g-recaptcha"
-                            data-sitekey="${recaptchaSiteKey}" data-callback="onSubmitRecaptcha" data-action="${recaptchaAction}" type="submit" id="kc-submit">
-                        ${msg("doRegister")}
-                    </button>
+                    <#if captchaProviderId == "registration-hcaptcha-action">
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}" id="kc-submit"/>
+                    <#else>
+                        <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} g-recaptcha"
+                                data-sitekey="${recaptchaSiteKey}" data-callback="onSubmitRecaptcha"<#if recaptchaAction?has_content> data-action="${recaptchaAction}"</#if> type="submit" id="kc-submit">
+                            ${msg("doRegister")}
+                        </button>
+                    </#if>
                 </div>
             <#else>
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">


### PR DESCRIPTION
## Summary
- generalize the registration captcha base so providers can supply their response field names, template metadata, and scripts
- add an hCaptcha form action with service registration, theme updates, and documentation for configuring the provider
- extend admin provider tests to expect the hCaptcha action in addition to the existing reCAPTCHA entries